### PR TITLE
Codex model

### DIFF
--- a/lib/mushaf/codex/codex.ex
+++ b/lib/mushaf/codex/codex.ex
@@ -1,0 +1,16 @@
+defmodule Mushaf.Codex do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "codices" do
+    field :script, Ecto.Enum, values: [:uthmani, :urdu]
+    field :most_recent_page, :integer, default: 1
+
+    belongs_to :user, Mushaf.Accounts.User
+  end
+
+  def create_changeset(codex, attrs) do
+    codex
+    |> cast(attrs, [:script])
+  end
+end

--- a/lib/mushaf/codex/codex.ex
+++ b/lib/mushaf/codex/codex.ex
@@ -11,6 +11,21 @@ defmodule Mushaf.Codex do
 
   def create_changeset(codex, attrs) do
     codex
-    |> cast(attrs, [:script])
+    |> cast(attrs, [:script, :most_recent_page])
+    |> validate_most_recent_page(changeset)
+  end
+
+  defp validate_most_recent_page(changeset) do
+    page_no = get_field(changeset, :most_recent_page)
+    script = get_field(changeset, :script)
+    case script do
+      :uthamni ->
+        if page_no > 0 and page_no < 605 do
+          changeset
+        else
+          add_error(changeset, :most_recent_page, "Last page is invalid!")
+        end
+      :urdu -> changeset
+    end
   end
 end

--- a/lib/mushaf/codex/codex.ex
+++ b/lib/mushaf/codex/codex.ex
@@ -12,14 +12,14 @@ defmodule Mushaf.Codex do
   def create_changeset(codex, attrs) do
     codex
     |> cast(attrs, [:script, :most_recent_page])
-    |> validate_most_recent_page(changeset)
+    |> validate_most_recent_page()
   end
 
   defp validate_most_recent_page(changeset) do
     page_no = get_field(changeset, :most_recent_page)
     script = get_field(changeset, :script)
     case script do
-      :uthamni ->
+      :uthmani ->
         if page_no > 0 and page_no < 605 do
           changeset
         else

--- a/lib/mushaf/codices.ex
+++ b/lib/mushaf/codices.ex
@@ -1,0 +1,18 @@
+defmodule Mushaf.Codices do
+
+  import Ecto.Query
+  alias Mushaf.Repo
+  alias Mushaf.Codex
+  alias Mushaf.Accounts
+
+  def get_codices_by_user(user) do
+    Repo.get_by(Codex, user: user)
+  end
+
+  def create_codex(%Accounts.User{} = user, attrs) do
+    %Codex{}
+    |> Codex.create_changeset(attrs)
+    |> Ecto.Changeset.put_assoc(:user, user)
+    |> Repo.insert()
+  end
+end

--- a/lib/mushaf_web/controllers/codex_controller.ex
+++ b/lib/mushaf_web/controllers/codex_controller.ex
@@ -1,0 +1,21 @@
+defmodule MushafWeb.CodexController do
+  use MushafWeb, :controller
+  alias Mushaf.Codices
+
+  def action(conn, _) do
+    args = [conn, conn.params, conn.assigns.current_user]
+    apply(__MODULE__, action_name(conn), args)
+  end
+
+  def create(conn, %{"codex" => codex_params}, current_user) do
+    case Codices.create_codex(current_user, codex_params) do
+      {:ok, codex} ->
+        conn
+        |> put_flash(:info, "Your new Mushaf is ready to go!")
+        # TODO: redirect here to page 1 of that mushaf
+      {:error, %Ecto.Changeset{} = changeset} ->
+        conn
+        |> put_flash(:error, "Couldn't create your Mushaf, try again?")
+    end
+  end
+end

--- a/priv/repo/migrations/20220406170347_create_codex.exs
+++ b/priv/repo/migrations/20220406170347_create_codex.exs
@@ -1,0 +1,12 @@
+defmodule Mushaf.Repo.Migrations.CreateCodex do
+  use Ecto.Migration
+  use Ecto.Schema
+
+  def change do
+    create table(:codices) do
+      add :script, :string, values: [:uthmani, :urdu]
+      add :line_count, :string, values: [:fifteen, :thirteen]
+      add :user_id, references(:users)
+    end
+  end
+end

--- a/priv/repo/migrations/20220406172405_add_most_recent_page_to_codex.exs
+++ b/priv/repo/migrations/20220406172405_add_most_recent_page_to_codex.exs
@@ -1,0 +1,9 @@
+defmodule Mushaf.Repo.Migrations.AddMostRecentPageToCodex do
+  use Ecto.Migration
+
+  def change do
+    alter table(:codices) do
+      add :most_recent_page, :integer, default: 1
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces a model, `codex`, to represent a person's copy of the mushaf.

The model has a `script` attribute that can take values of `uthmani` or `urdu`, a `most_recent_page`, and a `user` foreign key.